### PR TITLE
Map client and order persistence to existing database tables

### DIFF
--- a/src/Ecare.Application/Dtos/OrderDto.cs
+++ b/src/Ecare.Application/Dtos/OrderDto.cs
@@ -1,4 +1,4 @@
 using Ecare.Domain;
 
 namespace Ecare.Application.Dtos;
-public record OrderDto(string Number, string ProductName, string Unit, decimal Quantity, OrderStatus Status);
+public record OrderDto(string Number, string? Destination, string? DeliveryMode, string? TruckPlate, OrderStatus Status);

--- a/src/Ecare.Domain/Entities/Cart.cs
+++ b/src/Ecare.Domain/Entities/Cart.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Ecare.Domain.Entities;
+
+public class Cart
+{
+    public int Id { get; set; }
+    public int ProduitId { get; set; }
+    public string NomProduit { get; set; } = default!;
+    public decimal Quantite { get; set; }
+    public string? Unite { get; set; }
+    public DateTime DateAjout { get; set; }
+    public Guid UserId { get; set; }
+    public Guid? ShippingId { get; set; }
+}

--- a/src/Ecare.Domain/Entities/Client.cs
+++ b/src/Ecare.Domain/Entities/Client.cs
@@ -3,5 +3,6 @@ public class Client
 {
     public Guid Id { get; init; }
     public string Name { get; set; } = default!;
-    public bool SapOk { get; set; }
+    public string? SapCode { get; set; }
+    public bool SapOk => !string.IsNullOrWhiteSpace(SapCode);
 }

--- a/src/Ecare.Domain/Entities/EcareCiment.cs
+++ b/src/Ecare.Domain/Entities/EcareCiment.cs
@@ -1,0 +1,11 @@
+namespace Ecare.Domain.Entities;
+
+public class EcareCiment
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = default!;
+    public string? ImageUrl { get; set; }
+    public string? Details { get; set; }
+    public string? Type { get; set; }
+    public string? Description { get; set; }
+}

--- a/src/Ecare.Domain/Entities/Order.cs
+++ b/src/Ecare.Domain/Entities/Order.cs
@@ -4,14 +4,21 @@ using Ecare.Domain;
 public class Order
 {
     public Guid Id { get; set; }
+    public Guid? ShippingId { get; set; }
     public string Number { get; set; } = default!;
-    public Guid DriverId { get; set; }
-    public Guid ClientId { get; set; }
-    public int ProductId { get; set; }
-    public ProductType ProductType { get; set; }
-    public string ProductName { get; set; } = default!;
-    public string Unit { get; set; } = default!; // Tonnes/Sac/Camion
-    public decimal Quantity { get; set; }
+    public DateTime? OrderedAt { get; set; }
+    public string? Destination { get; set; }
+    public string? DeliveryMode { get; set; }
+    public string? LoadingLocation { get; set; }
+    public string? LoadingMethod { get; set; }
+    public TimeSpan? PickupTime { get; set; }
+    public TimeSpan? DeliveryTime { get; set; }
+    public string? SlvCard { get; set; }
+    public string? DriverLastName { get; set; }
+    public string? DriverFirstName { get; set; }
+    public string? DriverLicense { get; set; }
+    public string? TruckPlate { get; set; }
     public OrderStatus Status { get; set; } = OrderStatus.Cree;
-    public DateTime CreatedAt { get; set; }
+    public Guid? UserId { get; set; }
+    public decimal? TargetQuantityTons { get; set; }
 }

--- a/src/Ecare.Domain/Entities/OrderItem.cs
+++ b/src/Ecare.Domain/Entities/OrderItem.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Ecare.Domain.Entities;
+
+public class OrderItem
+{
+    public int Id { get; set; }
+    public Guid OrderId { get; set; }
+    public int ProductId { get; set; }
+    public decimal Quantity { get; set; }
+    public string? Unite { get; set; }
+}

--- a/src/Ecare.Domain/Entities/Shipping.cs
+++ b/src/Ecare.Domain/Entities/Shipping.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Ecare.Domain.Entities;
+
+public class Shipping
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public string? Destination { get; set; }
+    public string? DeliveryMode { get; set; }
+    public DateTime? DeliveryTime { get; set; }
+    public string? NumeroCommande { get; set; }
+    public string? LoadingMethod { get; set; }
+    public string? LoadingLocation { get; set; }
+    public DateTime? PickupTime { get; set; }
+    public string? SlvCard { get; set; }
+    public Guid? DriverId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public string? Commentaire { get; set; }
+}

--- a/src/Ecare.Infrastructure/Persistence/Configurations/CartConfiguration.cs
+++ b/src/Ecare.Infrastructure/Persistence/Configurations/CartConfiguration.cs
@@ -1,0 +1,44 @@
+using Ecare.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Ecare.Infrastructure.Persistence.Configurations;
+
+public sealed class CartConfiguration : IEntityTypeConfiguration<Cart>
+{
+    public void Configure(EntityTypeBuilder<Cart> builder)
+    {
+        builder.ToTable("Carts", schema: "dbo");
+
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.Id)
+            .HasColumnName("Id");
+
+        builder.Property(c => c.ProduitId)
+            .HasColumnName("ProduitId")
+            .IsRequired();
+
+        builder.Property(c => c.NomProduit)
+            .HasColumnName("NomProduit")
+            .IsRequired();
+
+        builder.Property(c => c.Quantite)
+            .HasColumnName("Quantite")
+            .IsRequired();
+
+        builder.Property(c => c.Unite)
+            .HasColumnName("Unite");
+
+        builder.Property(c => c.DateAjout)
+            .HasColumnName("DateAjout")
+            .IsRequired();
+
+        builder.Property(c => c.UserId)
+            .HasColumnName("UserId")
+            .IsRequired();
+
+        builder.Property(c => c.ShippingId)
+            .HasColumnName("ShippingId");
+    }
+}

--- a/src/Ecare.Infrastructure/Persistence/Configurations/ClientConfiguration.cs
+++ b/src/Ecare.Infrastructure/Persistence/Configurations/ClientConfiguration.cs
@@ -8,15 +8,23 @@ public sealed class ClientConfiguration : IEntityTypeConfiguration<Client>
 {
     public void Configure(EntityTypeBuilder<Client> builder)
     {
-        builder.ToTable("Ecare_Kiosk_Clients");
+        builder.ToTable("Client", schema: "dbo");
 
         builder.HasKey(c => c.Id);
 
+        builder.Property(c => c.Id)
+            .HasColumnName("Client_Id");
+
         builder.Property(c => c.Name)
-            .HasMaxLength(120)
+            .HasColumnName("Nom_Complet")
+            .HasMaxLength(200)
             .IsRequired();
 
-        builder.Property(c => c.SapOk)
-            .IsRequired();
+        builder.Property(c => c.SapCode)
+            .HasColumnName("CodeClientSap")
+            .HasMaxLength(50)
+            .IsRequired(false);
+
+        builder.Ignore(c => c.SapOk);
     }
 }

--- a/src/Ecare.Infrastructure/Persistence/Configurations/EcareCimentConfiguration.cs
+++ b/src/Ecare.Infrastructure/Persistence/Configurations/EcareCimentConfiguration.cs
@@ -1,0 +1,34 @@
+using Ecare.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Ecare.Infrastructure.Persistence.Configurations;
+
+public sealed class EcareCimentConfiguration : IEntityTypeConfiguration<EcareCiment>
+{
+    public void Configure(EntityTypeBuilder<EcareCiment> builder)
+    {
+        builder.ToTable("EcareCiments", schema: "dbo");
+
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.Id)
+            .HasColumnName("Id");
+
+        builder.Property(c => c.Name)
+            .HasColumnName("Name")
+            .IsRequired();
+
+        builder.Property(c => c.ImageUrl)
+            .HasColumnName("ImageUrl");
+
+        builder.Property(c => c.Details)
+            .HasColumnName("Details");
+
+        builder.Property(c => c.Type)
+            .HasColumnName("Type");
+
+        builder.Property(c => c.Description)
+            .HasColumnName("Description");
+    }
+}

--- a/src/Ecare.Infrastructure/Persistence/Configurations/OrderConfiguration.cs
+++ b/src/Ecare.Infrastructure/Persistence/Configurations/OrderConfiguration.cs
@@ -9,53 +9,91 @@ public sealed class OrderConfiguration : IEntityTypeConfiguration<Order>
 {
     public void Configure(EntityTypeBuilder<Order> builder)
     {
-        builder.ToTable("Ecare_Kiosk_Orders");
+        builder.ToTable("Orders", schema: "dbo");
 
         builder.HasKey(o => o.Id);
 
         builder.HasIndex(o => o.Number)
             .IsUnique();
 
+        builder.Property(o => o.Id)
+            .HasColumnName("Id");
+
+        builder.Property(o => o.ShippingId)
+            .HasColumnName("ShippingId")
+            .IsRequired(false);
+
         builder.Property(o => o.Number)
-            .HasMaxLength(40)
+            .HasColumnName("NumeroCommande")
+            .HasMaxLength(60)
             .IsRequired();
 
-        builder.Property(o => o.ProductId)
-            .IsRequired();
+        builder.Property(o => o.OrderedAt)
+            .HasColumnName("DateCommande")
+            .IsRequired(false);
 
-        builder.Property(o => o.ProductType)
-            .HasConversion<int>()
-            .IsRequired();
+        builder.Property(o => o.Destination)
+            .HasColumnName("Destination")
+            .HasMaxLength(255)
+            .IsRequired(false);
 
-        builder.Property(o => o.ProductName)
+        builder.Property(o => o.DeliveryMode)
+            .HasColumnName("ModeDelivraison")
             .HasMaxLength(120)
-            .IsRequired();
+            .IsRequired(false);
 
-        builder.Property(o => o.Unit)
-            .HasMaxLength(20)
-            .IsRequired();
+        builder.Property(o => o.LoadingLocation)
+            .HasColumnName("EmplacementChargement")
+            .HasMaxLength(255)
+            .IsRequired(false);
 
-        builder.Property(o => o.Quantity)
-            .HasPrecision(18, 3)
-            .IsRequired();
+        builder.Property(o => o.LoadingMethod)
+            .HasColumnName("MethodeChargement")
+            .HasMaxLength(120)
+            .IsRequired(false);
+
+        builder.Property(o => o.PickupTime)
+            .HasColumnName("HeureEnlevement")
+            .IsRequired(false);
+
+        builder.Property(o => o.DeliveryTime)
+            .HasColumnName("HeureDelivraison")
+            .IsRequired(false);
+
+        builder.Property(o => o.SlvCard)
+            .HasColumnName("CarteSLV")
+            .HasMaxLength(50)
+            .IsRequired(false);
+
+        builder.Property(o => o.DriverLastName)
+            .HasColumnName("ChauffeurNom")
+            .HasMaxLength(120)
+            .IsRequired(false);
+
+        builder.Property(o => o.DriverFirstName)
+            .HasColumnName("ChauffeurPrenom")
+            .HasMaxLength(120)
+            .IsRequired(false);
+
+        builder.Property(o => o.DriverLicense)
+            .HasColumnName("PermisDeConduire")
+            .HasMaxLength(80)
+            .IsRequired(false);
+
+        builder.Property(o => o.TruckPlate)
+            .HasColumnName("PlaqueCamion")
+            .HasMaxLength(50)
+            .IsRequired(false);
 
         builder.Property(o => o.Status)
+            .HasColumnName("Statut")
             .HasConversion<int>()
-            .HasDefaultValue(OrderStatus.Cree)
             .IsRequired();
 
-        builder.Property(o => o.CreatedAt)
-            .HasDefaultValueSql("SYSUTCDATETIME()")
-            .IsRequired();
+        builder.Property(o => o.UserId)
+            .HasColumnName("UserId")
+            .IsRequired(false);
 
-        builder.HasOne<Driver>()
-            .WithMany()
-            .HasForeignKey(o => o.DriverId)
-            .OnDelete(DeleteBehavior.Restrict);
-
-        builder.HasOne<Client>()
-            .WithMany()
-            .HasForeignKey(o => o.ClientId)
-            .OnDelete(DeleteBehavior.Restrict);
+        builder.Ignore(o => o.TargetQuantityTons);
     }
 }

--- a/src/Ecare.Infrastructure/Persistence/Configurations/OrderItemConfiguration.cs
+++ b/src/Ecare.Infrastructure/Persistence/Configurations/OrderItemConfiguration.cs
@@ -1,0 +1,33 @@
+using Ecare.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Ecare.Infrastructure.Persistence.Configurations;
+
+public sealed class OrderItemConfiguration : IEntityTypeConfiguration<OrderItem>
+{
+    public void Configure(EntityTypeBuilder<OrderItem> builder)
+    {
+        builder.ToTable("Ecare_OrderItems", schema: "dbo");
+
+        builder.HasKey(item => item.Id);
+
+        builder.Property(item => item.Id)
+            .HasColumnName("Id");
+
+        builder.Property(item => item.OrderId)
+            .HasColumnName("OrderId")
+            .IsRequired();
+
+        builder.Property(item => item.ProductId)
+            .HasColumnName("ProductId")
+            .IsRequired();
+
+        builder.Property(item => item.Quantity)
+            .HasColumnName("Quantity")
+            .IsRequired();
+
+        builder.Property(item => item.Unite)
+            .HasColumnName("Unite");
+    }
+}

--- a/src/Ecare.Infrastructure/Persistence/Configurations/ShippingConfiguration.cs
+++ b/src/Ecare.Infrastructure/Persistence/Configurations/ShippingConfiguration.cs
@@ -1,0 +1,56 @@
+using Ecare.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Ecare.Infrastructure.Persistence.Configurations;
+
+public sealed class ShippingConfiguration : IEntityTypeConfiguration<Shipping>
+{
+    public void Configure(EntityTypeBuilder<Shipping> builder)
+    {
+        builder.ToTable("Shippings", schema: "dbo");
+
+        builder.HasKey(s => s.Id);
+
+        builder.Property(s => s.Id)
+            .HasColumnName("Id");
+
+        builder.Property(s => s.UserId)
+            .HasColumnName("UserId")
+            .IsRequired();
+
+        builder.Property(s => s.Destination)
+            .HasColumnName("Destination");
+
+        builder.Property(s => s.DeliveryMode)
+            .HasColumnName("ModeDelivraison");
+
+        builder.Property(s => s.DeliveryTime)
+            .HasColumnName("HeureDelivraison");
+
+        builder.Property(s => s.NumeroCommande)
+            .HasColumnName("NumeroCommande");
+
+        builder.Property(s => s.LoadingMethod)
+            .HasColumnName("MethodeChargement");
+
+        builder.Property(s => s.LoadingLocation)
+            .HasColumnName("EmplacementChargement");
+
+        builder.Property(s => s.PickupTime)
+            .HasColumnName("HeureEnlevement");
+
+        builder.Property(s => s.SlvCard)
+            .HasColumnName("CarteSLV");
+
+        builder.Property(s => s.DriverId)
+            .HasColumnName("ChauffeurId");
+
+        builder.Property(s => s.CreatedAt)
+            .HasColumnName("DateCreation")
+            .IsRequired();
+
+        builder.Property(s => s.Commentaire)
+            .HasColumnName("Commentaire");
+    }
+}

--- a/src/Ecare.Infrastructure/Persistence/EcareDbContext.cs
+++ b/src/Ecare.Infrastructure/Persistence/EcareDbContext.cs
@@ -11,6 +11,10 @@ public class EcareDbContext(DbContextOptions<EcareDbContext> options) : DbContex
     public DbSet<Order> Orders => Set<Order>();
     public DbSet<WeighRecord> Weighings => Set<WeighRecord>();
     public DbSet<BonLivraison> BonLivraisons => Set<BonLivraison>();
+    public DbSet<EcareCiment> EcareCiments => Set<EcareCiment>();
+    public DbSet<OrderItem> OrderItems => Set<OrderItem>();
+    public DbSet<Shipping> Shippings => Set<Shipping>();
+    public DbSet<Cart> Carts => Set<Cart>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
         => modelBuilder.ApplyConfigurationsFromAssembly(typeof(EcareDbContext).Assembly);

--- a/src/Ecare.Shared/DbTableNames.cs
+++ b/src/Ecare.Shared/DbTableNames.cs
@@ -8,4 +8,8 @@ public static class DbTableNames
     public const string Orders = "[dbo].[Orders]";
     public const string Weighings = "Ecare_Kiosk_Weighings";
     public const string BonLivraison = "Ecare_Kiosk_BonLivraison";
+    public const string EcareCiments = "[dbo].[EcareCiments]";
+    public const string EcareOrderItems = "[dbo].[Ecare_OrderItems]";
+    public const string Shippings = "[dbo].[Shippings]";
+    public const string Carts = "[dbo].[Carts]";
 }

--- a/src/Ecare.Shared/DbTableNames.cs
+++ b/src/Ecare.Shared/DbTableNames.cs
@@ -2,10 +2,10 @@ namespace Ecare.Shared;
 
 public static class DbTableNames
 {
-    public const string Clients = "Ecare_Kiosk_Clients";
+    public const string Clients = "[dbo].[Client]";
     public const string Drivers = "Ecare_Kiosk_Drivers";
     public const string Lines = "Ecare_Kiosk_Lines";
-    public const string Orders = "Ecare_Kiosk_Orders";
+    public const string Orders = "[dbo].[Orders]";
     public const string Weighings = "Ecare_Kiosk_Weighings";
     public const string BonLivraison = "Ecare_Kiosk_BonLivraison";
 }


### PR DESCRIPTION
## Summary
- update the shared table name constants so clients and orders use the existing dbo.Client and dbo.Orders tables
- align the client entity/configuration and scan handler to read SAP data from the legacy Client table
- remodel order persistence/repository logic to the legacy Orders schema and adjust DTOs/handlers accordingly

## Testing
- `dotnet build` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a376253c8329b846f97580bea270